### PR TITLE
fix: use relative path for favicon

### DIFF
--- a/docker/src/app/templates/index.html
+++ b/docker/src/app/templates/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>pytbak API</title>
-    <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.png') }}">
+    <link rel="shortcut icon" href="static/favicon.png">
 </head>
 <body>
     <h1>pytbak API</h1>


### PR DESCRIPTION
This commit changes the favicon link in the `index.html` template to use a relative path. This ensures that the favicon is loaded correctly when the application is served under a subpath (e.g., /api/).